### PR TITLE
Update vmimport-image-import.md

### DIFF
--- a/doc_source/vmimport-image-import.md
+++ b/doc_source/vmimport-image-import.md
@@ -101,12 +101,18 @@ If you encounter an error stating that "This policy contains invalid Json," doub
             "Effect":"Allow",
             "Action":[
                "s3:GetBucketLocation",
-               "s3:GetObject",
                "s3:ListBucket" 
             ],
             "Resource":[
                "arn:aws:s3:::disk-image-file-bucket",
-               "arn:aws:s3:::disk-image-file-bucket/*"
+            ]
+         },
+         {  "Effect":"Allow",
+            "Action":[
+               "s3:GetObject"
+            ],
+            "Resource":[
+            "arn:aws:s3:::disk-image-file-bucket/*"
             ]
          },
          {
@@ -114,7 +120,8 @@ If you encounter an error stating that "This policy contains invalid Json," doub
             "Action":[
                "ec2:ModifySnapshotAttribute",
                "ec2:CopySnapshot",
-               "ec2:RegisterImage",
+               "ec2:ImportImage",
+               "ec2:RegisterImage",
                "ec2:Describe*"
             ],
             "Resource":"*"


### PR DESCRIPTION
I separated the "Allow" rule for s3.GetObject as the role policy did not have sufficient rights during VM import when I included it in the other S3 "Allow" rule that includes s3.ListBucket and s3GetBucketLocation. Creating this separate rule with the resource of "arn:aws:s3:::disk-image-file-bucket/*" provides the correct rights needed to grab the image from S3 during the import process.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
