### PR TITLE
how-vm-import-export-works: Clarify S3 upload OOO

### DIFF
--- a/doc_source/how-vm-import-export-works.md
+++ b/doc_source/how-vm-import-export-works.md
@@ -23,7 +23,7 @@ The following table summarizes the key differences between image import and inst
 
 ## Image Import<a name="image-import"></a>
 
-First, you prepare your virtual machine for export, and then export it using one of the supported formats\. Next, you upload the VM image to Amazon S3 and then initiate the import task\. After the import task is complete, you can launch an instance from the AMI\. If you want, you can copy the AMI to other regions so that you can launch instances in those regions\.
+First, prepare your virtual machine for export, and then export it using one of the supported formats\. Next, upload the VM image to Amazon S3, and then start the image import task\. After the import task is complete, you can launch instances from the AMI\. If you want, you can copy the AMI to other Regions so that you can launch instances in those Regions\.
 
 The following diagram shows the process of exporting a VM from your virtualization environment to Amazon EC2 as an AMI\.
 
@@ -31,7 +31,7 @@ The following diagram shows the process of exporting a VM from your virtualizati
 
 ## Instance Import<a name="instance-import"></a>
 
-First, you prepare your virtual machine for export, and then export it using one of the supported formats\. Next, you upload the VM image to Amazon S3 and then initiate the import task which launches it as a stopped instance\. After the import task is complete, you can create an AMI from the instance\. If you want, you can copy the AMI to other regions so that you can launch instances in those regions\. You can also export a previously imported instance to your virtualization environment\.
+First, prepare your virtual machine for export, and then export it using one of the supported formats\. Next, upload the VM image to Amazon S3, and then start the instance import task\. After the import task is complete, you can create an AMI from the stopped  instance\. If you want, you can copy the AMI to other Regions so that you can launch instances in those Regions\. You can also export a previously imported instance to your virtualization environment\.
 
 The following diagram shows the process of exporting a VM from your virtualization environment to Amazon EC2 as an instance\.
 

--- a/doc_source/how-vm-import-export-works.md
+++ b/doc_source/how-vm-import-export-works.md
@@ -23,7 +23,7 @@ The following table summarizes the key differences between image import and inst
 
 ## Image Import<a name="image-import"></a>
 
-First, you prepare your virtual machine for export, and then export it using one of the supported formats\. Next, you start the import task, which uploads the VM image to Amazon S3 and creates an AMI\. After the import task is complete, you can launch an instance from the AMI\. If you want, you can copy the AMI to other regions so that you can launch instances in those regions\.
+First, you prepare your virtual machine for export, and then export it using one of the supported formats\. Next, you upload the VM image to Amazon S3 and then initiate the import task\. After the import task is complete, you can launch an instance from the AMI\. If you want, you can copy the AMI to other regions so that you can launch instances in those regions\.
 
 The following diagram shows the process of exporting a VM from your virtualization environment to Amazon EC2 as an AMI\.
 
@@ -31,7 +31,7 @@ The following diagram shows the process of exporting a VM from your virtualizati
 
 ## Instance Import<a name="instance-import"></a>
 
-First, you prepare your virtual machine for export, and then export it using one of the supported formats\. Next, you start the import task, which uploads the VM image to Amazon S3 and launches it as a stopped instance\. After the import task is complete, you can create an AMI from the instance\. If you want, you can copy the AMI to other regions so that you can launch instances in those regions\. You can also export a previously imported instance to your virtualization environment\.
+First, you prepare your virtual machine for export, and then export it using one of the supported formats\. Next, you upload the VM image to Amazon S3 and then initiate the import task which launches it as a stopped instance\. After the import task is complete, you can create an AMI from the instance\. If you want, you can copy the AMI to other regions so that you can launch instances in those regions\. You can also export a previously imported instance to your virtualization environment\.
 
 The following diagram shows the process of exporting a VM from your virtualization environment to Amazon EC2 as an instance\.
 


### PR DESCRIPTION
Order of operations for S3 upload is that you export the VM image, manually upload to S3, and then initiate the import process. VM Import does not automatically upload to S3.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
